### PR TITLE
Fix marking SteamWorks as optional

### DIFF
--- a/addons/sourcemod/scripting/shop.sp
+++ b/addons/sourcemod/scripting/shop.sp
@@ -256,9 +256,11 @@ public void OnConVarChange(ConVar convar, const char[] oldValue, const char[] ne
 
 public void OnMapStart()
 {
+#if defined _SteamWorks_Included
 	// Stats work
 	if (LibraryExists("SteamWorks"))
 		SteamWorks_SteamServersConnected();
+#endif
 
 	DB_OnMapStart();
 	

--- a/addons/sourcemod/scripting/shop.sp
+++ b/addons/sourcemod/scripting/shop.sp
@@ -2,9 +2,9 @@
 
 #include <sourcemod>
 #include <shop>
-#undef REQUIRE_PLUGIN
+#undef REQUIRE_EXTENSIONS
 #tryinclude <SteamWorks>
-#define REQUIRE_PLUGIN
+#define REQUIRE_EXTENSIONS
 
 #pragma newdecls required
 EngineVersion Engine_Version = Engine_Unknown;


### PR DESCRIPTION
This should mark SteamWorks correctly as optional.
In #40 we admitted mistake.
For marking extension as optional, we should undefine `REQUIRE_EXTENSIONS`, not `REQUIRE_PLUGIN`.

For more details, [see include](https://github.com/TiBarification/SteamWorks/blob/syntax/Pawn/includes/SteamWorks.inc#L427-L431).