### PR TITLE
Changed DataPack logic & fixed authorization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,18 @@ language: c
 #Set the build environment
 env:
   global:
-    - STEAMWORKS_VERS=SteamWorks-git121
+    - STEAMWORKS_VERS=SteamWorks-git131
     - INCLUDE=addons/sourcemod/scripting/include
     - SCRIPTING=addons/sourcemod/scripting
     - PLUGINS=addons/sourcemod/plugins
     - EXTENSIONS=addons/sourcemod/extensions
   matrix:
-    - SMVERSION=1.9
     - SMVERSION=1.10
+    - SMVERSION=1.11
 
 matrix:
   allow_failures:
-    - env: SMVERSION=1.10
+    - env: SMVERSION=1.11
 
 install:
     # Sourcemod download
@@ -33,7 +33,6 @@ install:
     - wget http://users.alliedmods.net/~kyles/builds/SteamWorks/$STEAMWORKS_VERS-windows.zip
     - tar -xzf $STEAMWORKS_VERS-linux.tar.gz $EXTENSIONS/SteamWorks.ext.so $INCLUDE/SteamWorks.inc
     - unzip -j $STEAMWORKS_VERS-windows.zip $EXTENSIONS/SteamWorks.ext.dll -d $EXTENSIONS
-    - wget "https://raw.githubusercontent.com/TiBarification/SteamWorks/syntax/Pawn/includes/SteamWorks.inc" -O $INCLUDE/SteamWorks.inc
 before_script:
     - chmod +x $SCRIPTING/spcomp
     - mkdir $SCRIPTING/compiled

--- a/addons/sourcemod/scripting/shop.sp
+++ b/addons/sourcemod/scripting/shop.sp
@@ -10,7 +10,6 @@
 EngineVersion Engine_Version = Engine_Unknown;
 
 int g_iMaxPageItems = 10;
-#define INVALID_DP_POS	view_as<DataPackPos>(-1)
 
 int global_timer;
 Panel panel_info;
@@ -46,7 +45,7 @@ ConVar g_hHideCategoriesItemsCount;
 #include "shop/stats.sp"
 #endif
 
-#define SHOP_VERSION "3.0D3" // 10.05.2019
+#define SHOP_VERSION "3.0D4" // 19.10.2019
 
 public Plugin myinfo =
 {

--- a/addons/sourcemod/scripting/shop.sp
+++ b/addons/sourcemod/scripting/shop.sp
@@ -181,7 +181,6 @@ public void OnPluginStart()
 	g_iMaxPageItems = GetMaxPageItems(GetMenuStyleHandle(MenuStyle_Default));
 
 	InitChat();
-	Admin_OnPluginStart();
 	DB_OnPluginStart();
 	Forward_OnPluginStart();
 	Functions_OnPluginStart();

--- a/addons/sourcemod/scripting/shop/admin.sp
+++ b/addons/sourcemod/scripting/shop/admin.sp
@@ -33,15 +33,6 @@ void Admin_CreateNatives()
 	CreateNative("Shop_ShowAdminMenu", Admin_ShowAdminMenu);
 }
 
-void Admin_OnPluginStart() {
-	DataPack hPack = new DataPack();
-	hPack.WriteCell(0); // plugin handle
-	hPack.WriteCell(0); // admin module display func handle
-	hPack.WriteCell(0); // admin module select func handle
-
-	delete hPack;
-}
-
 public int Admin_AddToMenuNative(Handle plugin, int numParams)
 {
 	DataPack dp = new DataPack();

--- a/addons/sourcemod/scripting/shop/functions.sp
+++ b/addons/sourcemod/scripting/shop/functions.sp
@@ -5,9 +5,9 @@ int g_iTransCredits;
 /**
  * For SM 1.10
  */
-stock DataPackPos FUNCTIONS_DP_PLUGIN 		= INVALID_DP_POS;
-stock DataPackPos FUNCTIONS_DP_FUNCDISPLAY	= INVALID_DP_POS;
-stock DataPackPos FUNCTIONS_DP_FUNCSELECT		= INVALID_DP_POS;
+stock DataPackPos FUNCTIONS_DP_PLUGIN 		= view_as<DataPackPos>(0);
+stock DataPackPos FUNCTIONS_DP_FUNCDISPLAY	= view_as<DataPackPos>(1);
+stock DataPackPos FUNCTIONS_DP_FUNCSELECT		= view_as<DataPackPos>(2);
 
 bool g_bListenChat[MAXPLAYERS+1];
 int g_iCreditsTransferTarget[MAXPLAYERS+1],
@@ -92,18 +92,10 @@ void Functions_OnPluginStart()
 	g_hLuckCredits = CreateConVar("sm_shop_luck_credits", "500", "How many credits the luck cost", 0, true, 0.0);
 	g_hLuckChance = CreateConVar("sm_shop_luck_chance", "20", "How many chance the luck can be succeded", 0, true, 1.0, true, 100.0);
 
-	/**
-	 * For SM 1.10
-	 */
+
 	DataPack hPack = new DataPack();
-
-	FUNCTIONS_DP_PLUGIN = hPack.Position;
 	hPack.WriteCell(0);
-
-	FUNCTIONS_DP_FUNCDISPLAY = hPack.Position;
 	hPack.WriteCell(0);
-
-	FUNCTIONS_DP_FUNCSELECT = hPack.Position;
 	hPack.WriteCell(0);
 
 	delete hPack;

--- a/addons/sourcemod/scripting/shop/functions.sp
+++ b/addons/sourcemod/scripting/shop/functions.sp
@@ -91,14 +91,6 @@ void Functions_OnPluginStart()
 	
 	g_hLuckCredits = CreateConVar("sm_shop_luck_credits", "500", "How many credits the luck cost", 0, true, 0.0);
 	g_hLuckChance = CreateConVar("sm_shop_luck_chance", "20", "How many chance the luck can be succeded", 0, true, 1.0, true, 100.0);
-
-
-	DataPack hPack = new DataPack();
-	hPack.WriteCell(0);
-	hPack.WriteCell(0);
-	hPack.WriteCell(0);
-
-	delete hPack;
 }
 
 public void Functions_OnConVarChange(ConVar convar, const char[] oldValue, const char[] newValue)

--- a/addons/sourcemod/scripting/shop/item_manager.sp
+++ b/addons/sourcemod/scripting/shop/item_manager.sp
@@ -7,26 +7,26 @@ KeyValues h_KvItems;
  * For SM 1.10
  * Items
  */
-stock DataPackPos ITEM_DATAPACKPOS_REGISTER			= INVALID_DP_POS;
-stock DataPackPos ITEM_DATAPACKPOS_USE 				= INVALID_DP_POS;
-stock DataPackPos ITEM_DATAPACKPOS_SHOULD_DISPLAY		= INVALID_DP_POS;
-stock DataPackPos ITEM_DATAPACKPOS_DISPLAY				= INVALID_DP_POS;
-stock DataPackPos ITEM_DATAPACKPOS_DESC				= INVALID_DP_POS;
-stock DataPackPos ITEM_DATAPACKPOS_COMMON				= INVALID_DP_POS;
-stock DataPackPos ITEM_DATAPACKPOS_BUY					= INVALID_DP_POS;
-stock DataPackPos ITEM_DATAPACKPOS_SELL				= INVALID_DP_POS;
-stock DataPackPos ITEM_DATAPACKPOS_ELAPSE				= INVALID_DP_POS;
+stock DataPackPos ITEM_DATAPACKPOS_REGISTER			= view_as<DataPackPos>(0);
+stock DataPackPos ITEM_DATAPACKPOS_USE 				= view_as<DataPackPos>(1);
+stock DataPackPos ITEM_DATAPACKPOS_SHOULD_DISPLAY		= view_as<DataPackPos>(2);
+stock DataPackPos ITEM_DATAPACKPOS_DISPLAY				= view_as<DataPackPos>(3);
+stock DataPackPos ITEM_DATAPACKPOS_DESC				= view_as<DataPackPos>(4);
+stock DataPackPos ITEM_DATAPACKPOS_COMMON				= view_as<DataPackPos>(5);
+stock DataPackPos ITEM_DATAPACKPOS_BUY					= view_as<DataPackPos>(6);
+stock DataPackPos ITEM_DATAPACKPOS_SELL				= view_as<DataPackPos>(7);
+stock DataPackPos ITEM_DATAPACKPOS_ELAPSE				= view_as<DataPackPos>(8);
 
 /**
  * For SM 1.10
  * Categories
  */
-stock DataPackPos CATEGORY_DATAPACKPOS_PLUGIN			= INVALID_DP_POS;
-stock DataPackPos CATEGORY_DATAPACKPOS_DISPLAY			= INVALID_DP_POS;
-stock DataPackPos CATEGORY_DATAPACKPOS_DESCRIPTION		= INVALID_DP_POS;
-stock DataPackPos CATEGORY_DATAPACKPOS_SHOULD_DISPLAY	= INVALID_DP_POS;
-stock DataPackPos CATEGORY_DATAPACKPOS_SELECT			= INVALID_DP_POS;
-stock DataPackPos CATEGORY_DATAPACKPOS_ITEMSCOUNT		= INVALID_DP_POS;
+stock DataPackPos CATEGORY_DATAPACKPOS_PLUGIN			= view_as<DataPackPos>(0);
+stock DataPackPos CATEGORY_DATAPACKPOS_DISPLAY			= view_as<DataPackPos>(1);
+stock DataPackPos CATEGORY_DATAPACKPOS_DESCRIPTION		= view_as<DataPackPos>(2);
+stock DataPackPos CATEGORY_DATAPACKPOS_SHOULD_DISPLAY	= view_as<DataPackPos>(3);
+stock DataPackPos CATEGORY_DATAPACKPOS_SELECT			= view_as<DataPackPos>(4);
+stock DataPackPos CATEGORY_DATAPACKPOS_ITEMSCOUNT		= view_as<DataPackPos>(5);
 
 void ItemManager_CreateNatives()
 {
@@ -101,32 +101,15 @@ void ItemManager_OnPluginStart()
 	 */
 	DataPack hPack = new DataPack();
 
-	ITEM_DATAPACKPOS_REGISTER = hPack.Position;
-	hPack.WriteCell(0);
-
-	ITEM_DATAPACKPOS_USE = hPack.Position;
-	hPack.WriteCell(0);
-
-	ITEM_DATAPACKPOS_SHOULD_DISPLAY = hPack.Position;
-	hPack.WriteCell(0);
-
-	ITEM_DATAPACKPOS_DISPLAY = hPack.Position;
-	hPack.WriteCell(0);
-
-	ITEM_DATAPACKPOS_DESC = hPack.Position;
-	hPack.WriteCell(0);
-
-	ITEM_DATAPACKPOS_COMMON = hPack.Position;
-	hPack.WriteCell(0);
-
-	ITEM_DATAPACKPOS_BUY = hPack.Position;
-	hPack.WriteCell(0);
-
-	ITEM_DATAPACKPOS_SELL = hPack.Position;
-	hPack.WriteCell(0);
-
-	ITEM_DATAPACKPOS_ELAPSE = hPack.Position;
-	hPack.WriteCell(0);
+	hPack.WriteCell(0); // register
+	hPack.WriteCell(0); // use
+	hPack.WriteCell(0); // should display
+	hPack.WriteCell(0); // display
+	hPack.WriteCell(0); // description
+	hPack.WriteCell(0); // common
+	hPack.WriteCell(0); // buy
+	hPack.WriteCell(0); // sell
+	hPack.WriteCell(0); // elapse
 
 	hPack.Reset(true);
 
@@ -134,23 +117,12 @@ void ItemManager_OnPluginStart()
 	 * For SM 1.10
 	 * Categories
 	 */
-	CATEGORY_DATAPACKPOS_PLUGIN = hPack.Position;
-	hPack.WriteCell(0);
-
-	CATEGORY_DATAPACKPOS_DISPLAY = hPack.Position;
-	hPack.WriteCell(0);
-
-	CATEGORY_DATAPACKPOS_DESCRIPTION = hPack.Position;
-	hPack.WriteCell(0);
-
-	CATEGORY_DATAPACKPOS_SHOULD_DISPLAY = hPack.Position;
-	hPack.WriteCell(0);
-
-	CATEGORY_DATAPACKPOS_SELECT = hPack.Position;
-	hPack.WriteCell(0);
-
-	CATEGORY_DATAPACKPOS_ITEMSCOUNT = hPack.Position;
-	hPack.WriteCell(0);
+	hPack.WriteCell(0); // plugin handle id
+	hPack.WriteCell(0); // category display
+	hPack.WriteCell(0); // category description
+	hPack.WriteCell(0); // category should display
+	hPack.WriteCell(0); // category select
+	hPack.WriteCell(0); // category items count
 
 	delete hPack;
 }

--- a/addons/sourcemod/scripting/shop/item_manager.sp
+++ b/addons/sourcemod/scripting/shop/item_manager.sp
@@ -94,37 +94,6 @@ void ItemManager_CreateNatives()
 void ItemManager_OnPluginStart()
 {
 	RegServerCmd("sm_items_dump", ItemManager_Dump);
-
-	/**
-	 * For SM 1.10
-	 * Items
-	 */
-	DataPack hPack = new DataPack();
-
-	hPack.WriteCell(0); // register
-	hPack.WriteCell(0); // use
-	hPack.WriteCell(0); // should display
-	hPack.WriteCell(0); // display
-	hPack.WriteCell(0); // description
-	hPack.WriteCell(0); // common
-	hPack.WriteCell(0); // buy
-	hPack.WriteCell(0); // sell
-	hPack.WriteCell(0); // elapse
-
-	hPack.Reset(true);
-
-	/**
-	 * For SM 1.10
-	 * Categories
-	 */
-	hPack.WriteCell(0); // plugin handle id
-	hPack.WriteCell(0); // category display
-	hPack.WriteCell(0); // category description
-	hPack.WriteCell(0); // category should display
-	hPack.WriteCell(0); // category select
-	hPack.WriteCell(0); // category items count
-
-	delete hPack;
 }
 
 public Action ItemManager_Dump(int argc)

--- a/addons/sourcemod/scripting/shop/player_manager.sp
+++ b/addons/sourcemod/scripting/shop/player_manager.sp
@@ -1160,6 +1160,7 @@ public int PlayerManager_AuthorizeClient(Database owner, DBResultSet hndl, const
 		{
 			iCredits[client] = dp.ReadCell();
 			i_Id[client] = hndl.InsertId;
+			g_bAuthorized[client] = true; // client doesn't have any item, so there are no reason to load them
 		}
 	}
 	delete dp;

--- a/addons/sourcemod/scripting/shop/stats.sp
+++ b/addons/sourcemod/scripting/shop/stats.sp
@@ -2,7 +2,7 @@ stock const char API_KEY[] = "e34fa2f3adb922bf76fb7b06807caa3c";
 stock const char URL[] = "http://stats.tibari.ru/api/v1/add_server";
 
 /* Stats pusher */
-public void SteamWorks_SteamServersConnected()
+public int SteamWorks_SteamServersConnected()
 {
 	int iIp[4];
 	


### PR DESCRIPTION
**Removed support of SM 1.9**
Fixed logic of datapacks, now supports features from SM 1.10.
Datapack addresses binded as static per compilation.
Updated required steamworks version to 131 build.
Updated logic when user inserted to database, he got message "Your data is being loaded!"