### PR TITLE
Improve includes commentaries for parsing

### DIFF
--- a/addons/sourcemod/scripting/include/shop.inc
+++ b/addons/sourcemod/scripting/include/shop.inc
@@ -72,230 +72,230 @@ enum ShopMenu
 
 /**
  *	Called when the shop is ready to register items
- *	-
+ *	
  *	@noparams
- *	-
+ *	
  *	@noreturn
 */
 forward void Shop_Started();
 
 /**
  *	Called when the plugin has loaded the player's data
- *	-
+ *	
  *	@param client		Client index
- *	-
+ *	
  *	@noreturn
  */
 forward void Shop_OnAuthorized(int client);
 
 /**
  *	Called when a menu is being titled
- *	-
+ *	
  *	@param client			Client index to whom a menu is being titled
  *	@param menu_action		Menu that is being titled
  *	@param title			Current title is being set
  *	@param buffer			New title to set
  *	@param maxlength		Maxlength of the title
- *	-
+ *	
  *	@return true to apply new value and false to ignore
 */
 forward bool Shop_OnMenuTitle(int client, ShopMenu menu_action, const char[] title, char[] buffer, int maxlength);
 
 /**
  *	Called when credits are being sent to a player
- *	-
+ *	
  *	@param client				Client index who is sending credits
  *	@param target				Client index to whom credits being sent
  *	@param amount_give			Amount of credits being given to a target player. By reference
  *	@param amount_remove		Amount of credits being taken from performing player.
  *	@param amount_commission	Amount of credits the commission was set. By reference
  *	@param bPercent				Whether the commission was set by the percent By reference
- *	-
+ *	
  *	@return Plugin_Changed to apply new values. >= Plugin_Handled to block
 */
 forward Action Shop_OnCreditsTransfer(int client, int target, int &amount_give, int &amount_remove, int &amount_commission, bool bPercent);
 
 /**
  *	Called when credits has been sent to a player
- *	-
+ *	
  *	@param client				Client index who sent credits
  *	@param target				Client index to whom credits were sent
  *	@param amount_give			Amount of credits has been given to a target player
  *	@param amount_remove		Amount of credits has been taken from a performing player
-  *	@param amount_commission	Amount of credits the commission was set
- *	-
+ *	@param amount_commission	Amount of credits the commission was set
+ *	
  *	@noreturn
 */
 forward void Shop_OnCreditsTransfered(int client, int target, int amount_give, int amount_remove, int amount_commission);
 
 /**
  *	Called when a player is being set credits to
- *	-
+ *	
  *	@param client			Client index who is being set to
  *	@param credits			Amount of credits a client is being set to. By reference
  *	@param by_who			See CREDITS_BY_* definitions for more info and any higher value is the admin index
- *	-
+ *	
  *	@return Plugin_Changed to apply new values. >= Plugin_Handled to block
 */
 forward Action Shop_OnCreditsSet(int client, int &credits, int by_who);
 
 /**
  *	Called when a player is being given credits to
- *	-
+ *	
  *	@param client			Client index who is being given to
  *	@param credits			Amount of credits a client is being given to. By reference
  *	@param by_who			See CREDITS_BY_* definitions for more info and any higher values is the admin index
- *	-
+ *	
  *	@return Plugin_Changed to apply new values. >= Plugin_Handled to block
 */
 forward Action Shop_OnCreditsGiven(int client, int &credits, int by_who);
 
 /**
  *	Called when a player is being taken credits from
- *	-
+ *	
  *	@param client			Client index who is being taken from
  *	@param credits			Amount of credits a client is being taken for. By reference
  *	@param by_who			See CREDITS_BY_* definitions for more info and any higher value is the admin index
- *	-
+ *	
  *	@return Plugin_Changed to apply new values. >= Plugin_Handled to block
 */
 forward Action Shop_OnCreditsTaken(int client, int &credits, int by_who);
 
 /**
  *	Called when a player is being set gold to
- *	-
+ *	
  *	@param client			Client index who is being set to
  *	@param amount			Amount of gold a client is being set to. By reference
  *	@param by_who			See CREDITS_BY_* definitions for more info and any higher value is the admin index
- *	-
+ *	
  *	@return Plugin_Changed to apply new values. >= Plugin_Handled to block
 */
 forward Action Shop_OnGoldSet(int client, int &amount, int by_who);
 
 /**
  *	Called when a player is being given gold to
- *	-
+ *	
  *	@param client			Client index who is being given to
  *	@param amount			Amount of gold a client is being given to. By reference
  *	@param by_who			See CREDITS_BY_* definitions for more info and any higher values is the admin index
- *	-
+ *	
  *	@return Plugin_Changed to apply new values. >= Plugin_Handled to block
 */
 forward Action Shop_OnGoldGiven(int client, int &amount, int by_who);
 
 /**
  *	Called when a player is being taken gold from
- *	-
+ *	
  *	@param client			Client index who is being taken from
  *	@param amount			Amount of gold a client is being taken for. By reference
  *	@param by_who			See CREDITS_BY_* definitions for more info and any higher value is the admin index
- *	-
+ *	
  *	@return Plugin_Changed to apply new values. >= Plugin_Handled to block
 */
 forward Action Shop_OnGoldTaken(int client, int &amount, int by_who);
 
 /**
  *	Called when a player is trying to try a luck
- *	-
+ *	
  *	@param client			Client index who is perfroming
- *	-
+ *	
  *	@return true to allow performing and false to block
 */
 forward bool Shop_OnClientLuckProcess(int client);
 
 /**
  *	Called when a player is nearly to win an item
- *	-
+ *	
  *	@param client			Client index who is nearly to win
  *	@param item_id			Item id of the item
- *	-
+ *	
  *	@return true to allow and false to block
 */
 forward bool Shop_OnClientShouldLuckItem(int client, ItemId item_id);
 
 /**
  *	Called when a player has won an item
- *	-
+ *	
  *	@param client			Client index who has won
  *	@param item_id			Item id of the item
- *	-
+ *	
  *	@noreturn
 */
 forward void Shop_OnClientItemLucked(int client, ItemId item_id);
 
 /**
  *	Checks whether the shop has been started
- *	-
+ *	
  *	@noparams
- *	-
+ *	
  *	@return	True if the shop is already started, false otherwise
 */
 native bool Shop_IsStarted();
 
 /**
  *	This must be called on PluginEnd. Fully unregisters the plugin. Unregisters items, categories and removes them from the shop and players' inventory
- *	-
+ *	
  *	@noparams
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_UnregisterMe();
 
 /**
  *	Shows a player an item's panel
- *	-
+ *	
  *	@param client			Client index
  *	@param item_id			Item id of the item
- *	-
+ *	
  *	@return true if a panel has been shown, false otherwise
 */
 native bool Shop_ShowItemPanel(int client, ItemId item_id);
 
 /**
  *	Opens main menu for a player
- *	-
+ *	
  *	@param client			Client index
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_OpenMainMenu(int client);
 
 /**
  *	Shows a player categories of the shop
- *	-
+ *	
  *	@param client			Client index
- *	-
+ *	
  *	@return true if categories has been shown, false otherwise
 */
 native bool Shop_ShowCategory(int client);
 
 /**
  *	Shows a player his inventory
- *	-
+ *	
  *	@param client			Client index
- *	-
+ *	
  *	@return true if the inventory has been shown, false otherwise
 */
 native bool Shop_ShowInventory(int client);
 
 /**
  *	Shows a player items of a category
- *	-
+ *	
  *	@param client			Client index
  *	@param category_id		Category id to show
  *	@param inventory		To show items of his inventory
- *	-
+ *	
  *	@return true if the items has been shown, false otherwise
 */
 native bool Shop_ShowItemsOfCategory(int client, CategoryId category_id, bool inventory = false);
 
 /**
  *	Get path to the main config folder of the Shop
- *	-
+ *	
  *	@param buffer			Buffer to store the path in
  *	@param size				Max buffer length
  *	@param file				File to retrieve the path for
- *	-
+ *	
  *	@noreturn
 */
 stock void Shop_GetCfgFile(char[] buffer, int size, const char[] file)

--- a/addons/sourcemod/scripting/include/shop/admin.inc
+++ b/addons/sourcemod/scripting/include/shop/admin.inc
@@ -1,48 +1,48 @@
 /**
  *	Called when an item from admin panel is being displayed
- *	-
+ *	
  *	@param client			Client index an item is being shown to
  *	@param buffer			Buffer to store display name
  *	@param maxlength		Max length of the buffer
- *	-
+ *	
  *	@noreturn
 */
 typedef Shop_AdminDisplay = function void (int client, char[] buffer, int maxlength);
 
 /**
  *	Called when an item from admin panel is being selected
- *	-
+ *	
  *	@param client			Client index performing selection
- *	-
+ *	
  *	@return true to allow performing and false to block
 */
 typedef Shop_AdminSelect = function bool (int client);
 
 /**
  *	Adds an item to the admin panel
- *	-
+ *	
  *	@param callback_display			Callback when the item is being shown. Set display name in the callback
  *	@param callback_select			Callback when the item is being selected
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_AddToAdminMenu(Shop_AdminDisplay callback_display, Shop_AdminSelect callback_select);
 
 /**
  *	Removes an item from the admin panel
- *	-
+ *	
  *	@param callback_display			Callback to remove
  *	@param callback_select			Callback to remove
- *	-
+ *	
  *	@return true on success, false otherwise
 */
 native bool Shop_RemoveFromAdminMenu(Shop_AdminDisplay callback_display, Shop_AdminSelect callback_select);
 
 /**
  *	Shows admin panel to a player
- *	-
+ *	
  *	@param client			Client index to show to
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_ShowAdminMenu(int client);

--- a/addons/sourcemod/scripting/include/shop/db.inc
+++ b/addons/sourcemod/scripting/include/shop/db.inc
@@ -7,28 +7,28 @@ enum ShopDBType
 
 /**
  *	Get the database handle. Must be freed with CloseHandle()
- *	-
+ *	
  *	@noparams
- *	-
+ *	
  *	@return	Database Handle
 */
 native Database Shop_GetDatabase();
 
 /**
  *	Gets the database type. See ShopDBType enumeration
- *	-
+ *	
  *	@noparams
- *	-
+ *	
  *	@return	Database type
 */
 native ShopDBType Shop_GetDatabaseType();
 
 /**
  *	Get the database prefix
- *	-
+ *	
  *	@param buffer			Buffer to store the prefix in
  *	@param maxlength		Max buffer length
- *	-
+ *	
  *	@return	Number of bytes written
 */
 native int Shop_GetDatabasePrefix(char[] buffer, int maxlength);

--- a/addons/sourcemod/scripting/include/shop/functions.inc
+++ b/addons/sourcemod/scripting/include/shop/functions.inc
@@ -1,48 +1,48 @@
 /**
  *	Called when an item from functions menu is being displayed
- *	-
+ *	
  *	@param client			Client index an item is being shown to
  *	@param buffer			Buffer to store display name
  *	@param maxlength		Max length of the buffer
- *	-
+ *	
  *	@noreturn
 */
 typedef Shop_FuncDisplay = function void (int client, char[] buffer, int maxlength);
 
 /**
  *	Called when an item from functions menu is being selected
- *	-
+ *	
  *	@param client			Client index performing selection
- *	-
+ *	
  *	@return true to allow performing and false to block
 */
 typedef Shop_FuncSelect = function bool (int client);
 
 /**
  *	Adds an item to the functions menu
- *	-
+ *	
  *	@param callback_display			Callback when the item is being shown. Set display name in the callback
  *	@param callback_select			Callback when the item is being selected
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_AddToFunctionsMenu(Shop_FuncDisplay callback_display, Shop_FuncSelect callback_select);
 
 /**
  *	Removes an item from the functions menu
- *	-
+ *	
  *	@param callback_display			Callback to remove
  *	@param callback_select			Callback to remove
- *	-
+ *	
  *	@return true on success, false otherwise
 */
 native bool Shop_RemoveFromFunctionsMenu(Shop_FuncDisplay callback_display, Shop_FuncSelect callback_select);
 
 /**
  *	Shows functions menu to a player
- *	-
+ *	
  *	@param client			Client index to show to
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_ShowFunctionsMenu(int client);

--- a/addons/sourcemod/scripting/include/shop/items.inc
+++ b/addons/sourcemod/scripting/include/shop/items.inc
@@ -1,19 +1,19 @@
 /**
  *	Called when an item is being drawn
- *	-
+ *	
  *	@param client			Client index an item is being drawn to
  *	@param menu_action		Menu performing this action
  *	@param category_id		Category id of an item
  *	@param item_id			Item id of an item
  *	@param disable			Whether an item should be disabled of to be selected
- *	-
+ *	
  *	@return Plugin_Changed to apply new values. >= Plugin_Handled to block an item to shown. Plugin_Continue otherwise
 */
 forward Action Shop_OnItemDraw(int client, ShopMenu menu_action, CategoryId category_id, ItemId item_id, bool &disable);
 
 /**
  *	Called when an item is being displayd
- *	-
+ *	
  *	@param client			Client index an item is being displayed to
  *	@param menu_action		Menu performing this action
  *	@param category_id		Category id of an item
@@ -21,14 +21,14 @@ forward Action Shop_OnItemDraw(int client, ShopMenu menu_action, CategoryId cate
  *	@param display			Display name being shown
  *	@param buffer			Buffer to store new display name
  *	@param maxlength		Max length of the buffer
- *	-
+ *	
  *	@return true to apply new display name, false otherwise
 */
 forward bool Shop_OnItemDisplay(int client, ShopMenu menu_action, CategoryId category_id, ItemId item_id, const char[] display, char[] buffer, int maxlength);
 
 /**
  *	Called when an item's description is being displayd
- *	-
+ *	
  *	@param client			Client index an item's description is being displayed to
  *	@param menu_action		Menu performing this action
  *	@param category_id		Category id of an item
@@ -36,14 +36,14 @@ forward bool Shop_OnItemDisplay(int client, ShopMenu menu_action, CategoryId cat
  *	@param description		Description being shown
  *	@param buffer			Buffer to store new description
  *	@param maxlength		Max length of the buffer
- *	-
+ *	
  *	@return true to apply new description, false otherwise
 */
 forward bool Shop_OnItemDescription(int client, ShopMenu menu_action, CategoryId category_id, ItemId item_id, const char[] description, char[] buffer, int maxlength);
 
 /**
  *	Called when an item is being bought
- *	-
+ *	
  *	@param client			Client index that performing this
  *	@param category_id		Category id of an item
  *	@param category			Category unique name
@@ -55,14 +55,14 @@ forward bool Shop_OnItemDescription(int client, ShopMenu menu_action, CategoryId
  *	@param value			Count if the item is finite and duration if the item is togglable or non-togglable. Set by reference
  *	@param gold_price		Gold price of the item. Set by reference
 *	@param gold_sell_price	Gold sell price of the item. Set by reference
- *	-
+ *	
  *	@return Plugin_Changed to apply new values. >= Plugin_Handled to block. Plugin_Continue otherwise
 */
 forward Action Shop_OnItemBuy(int client, CategoryId category_id, const char[] category, ItemId item_id, const char[] item, ItemType type, int &price, int &sell_price, int &value, int &gold_price, int &gold_sell_price);
 
 /**
  *	Called when an item is being bought
- *	-
+ *	
  *	@param client			Client index that performing this
  *	@param category_id		Category id of an item
  *	@param category			Category unique name
@@ -71,415 +71,415 @@ forward Action Shop_OnItemBuy(int client, CategoryId category_id, const char[] c
  *	@param type				Item type
  *	@param sell_price		Sell price of the item. Set by reference
  *	@param gold_sell_price  Gold sell price of the item. Set by reference
- *	-
+ *	
  *	@return Plugin_Changed to apply new values. >= Plugin_Handled to block. Plugin_Continue otherwise
 */
 forward Action Shop_OnItemSell(int client, CategoryId category_id, const char[] category, ItemId item_id, const char[] item, ItemType type, int &sell_price, int &gold_sell_price);
 
 /**
  *	Called when an item has been toggled
- *	-
+ *	
  *	@param client			Client index that performing this
  *	@param category_id		Category id of an item
  *	@param category			Category unique name
  *	@param item_id			Item id of an item
  *	@param item				Item's unique name
  *	@param toggle			State of the toggle. See ToggleState enum
- *	-
+ *	
  *	@noreturn
 */
 forward void Shop_OnItemToggled(int client, CategoryId category_id, const char[] category, ItemId item_id, const char[] item, ToggleState toggle);
 
 /**
  *	Called when an item has been elapsed
- *	-
+ *	
  *	@param client			Client index whose item has been elapsed
  *	@param category_id		Category id of an item
  *	@param category			Category unique name
  *	@param item_id			Item id of an item
  *	@param item				Item's unique name
- *	-
+ *	
  *	@noreturn
 */
 forward void Shop_OnItemElapsed(int client, CategoryId category_id, const char[] category, ItemId item_id, const char[] item);
 
 /**
  *	Called when a player is transferring an item
- *	-
+ *	
  *	@param client			Origin player
  *	@param target			Destination player
  *	@param item_id			Item id of an item
- *	-
+ *	
  *	@return true to allow transfer and false to block
 */
 forward bool Shop_OnItemTransfer(int client, int target, ItemId item_id);
 
 /**
  *	Called when a player has transfered an item
- *	-
+ *	
  *	@param client			Origin player
  *	@param target			Destination player
  *	@param item_id			Item id of an item
- *	-
+ *	
  *	@noreturn
 */
 forward void Shop_OnItemTransfered(int client, int target, ItemId item_id);
 
 /**
  *	Gets an item custom info
- *	-
+ *	
  *	@param item_id				Item id
  *	@param info					Info key to get
  *	@param defaultvalue			Optional default value to use if the key is not found
- *	-
+ *	
  *	@return Integer value of the key
 */
 native int Shop_GetItemCustomInfo(ItemId item_id, const char[] info, int defaultvalue = 0);
 
 /**
  *	Sets an item custom info
- *	-
+ *	
  *	@param item_id				Item id
  *	@param info					Info key to set
  *	@param value				Value to set
- *	-
+ *	
  *	@return true on success, false otherwise
 */
 native bool Shop_SetItemCustomInfo(ItemId item_id, const char[] info, int value);
 
 /**
  *	Gets an item custom info
- *	-
+ *	
  *	@param item_id				Item id
  *	@param info					Info key to get
  *	@param defaultvalue			Optional default value to use if the key is not found
- *	-
+ *	
  *	@return Float value of the key
 */
 native float Shop_GetItemCustomInfoFloat(ItemId item_id, const char[] info, float defaultvalue = 0.0);
 
 /**
  *	Sets an item custom info
- *	-
+ *	
  *	@param item_id				Item id
  *	@param info					Info key to set
  *	@param value				Value to set
- *	-
+ *	
  *	@return true on success, false otherwise
 */
 native bool Shop_SetItemCustomInfoFloat(ItemId item_id, const char[] info, float value);
 
 /**
  *	Gets an item custom info
- *	-
+ *	
  *	@param item_id				Item id
  *	@param info					Info key to get
  *	@param buffer				Buffer to store the value in
  *	@param maxlength			Max length of the buffer
  *	@param defaultvalue			Optional default value to use if the key is not found
- *	-
+ *	
  *	@return Number of bytes written
 */
 native int Shop_GetItemCustomInfoString(ItemId item_id, const char[] info, char[] buffer, int maxlength, const char[] defaultvalue = "");
 
 /**
  *	Sets an item custom info
- *	-
+ *	
  *	@param item_id				Item id
  *	@param info					Info key to set
  *	@param value				Value to set
- *	-
+ *	
  *	@return true on success, false otherwise
 */
 native bool Shop_SetItemCustomInfoString(ItemId item_id, const char[] info, const char[] value);
 
 /**
  *	Copies SubKeys of a KeyValue structure to the item info
- *	-
+ *	
  *	@param item_id				Item id
  *	@param kv					KeyValue structure to copy
- *	-
+ *	
  *	@return true on success, false otherwise
 */
 native bool Shop_KvCopySubKeysItemCustomInfo(ItemId item_id, KeyValues kv);
 
 /**
  *	Gets an item credits price
- *	-
+ *	
  *	@param item_id				Item id
- *	-
+ *	
  *	@return Price of the item
 */
 native int Shop_GetItemPrice(ItemId item_id);
 
 /**
  *	Sets an item credits price
- *	-
+ *	
  *	@param item_id				Item id
  *	@param price				Price to set
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetItemPrice(ItemId item_id, int price);
 
 /**
  *	Gets an item gold price
- *	-
+ *	
  *	@param item_id				Item id
- *	-
+ *	
  *	@return Price of the item
 */
 native int Shop_GetItemGoldPrice(ItemId item_id);
 
 /**
  *	Sets an item gold price
- *	-
+ *	
  *	@param item_id				Item id
  *	@param price				Price to set
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetItemGoldPrice(ItemId item_id, int price);
 
 /**
  *	Gets an item luck chance
- *	-
+ *	
  *	@param item_id				Item id
- *	-
+ *	
  *	@return Luck chance of the item. From 0 to 100
 */
 native int Shop_GetItemLuckChance(ItemId item_id);
 
 /**
  *	Sets an item luck chance
- *	-
+ *	
  *	@param item_id				Item id
  *	@param luck_chance			Luck chance to set. From 0 to 100. 0 can not be lucked and 100 is always lucked by the general chance set in cvar. Default item chance is 100
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetItemLuckChance(ItemId item_id, int luck_chance);
 
 /**
  *	Gets an item credits sell price
- *	-
+ *	
  *	@param item_id				Item id
- *	-
+ *	
  *	@return Sell price of the item
 */
 native int Shop_GetItemSellPrice(ItemId item_id);
 
 /**
  *	Sets an item credits sell price
- *	-
+ *	
  *	@param item_id				Item id
  *	@param sell_price			Sell price to set
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetItemSellPrice(ItemId item_id, int sell_price);
 
 /**
  *	Gets an item gold sell price
- *	-
+ *	
  *	@param item_id				Item id
- *	-
+ *	
  *	@return Gold sell price of the item
 */
 native int Shop_GetItemGoldSellPrice(ItemId item_id);
 
 /**
  *	Sets an item gold sell price
- *	-
+ *	
  *	@param item_id				Item id
  *	@param sell_price			Gold sell price to set
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetItemGoldSellPrice(ItemId item_id, int sell_price);
 
 /**
  *	Gets an item count if item is finite and duration if item is togglable or non-togglable (-1 if duration is unlimited)
- *	-
+ *	
  *	@param item_id				Item id
- *	-
+ *	
  *	@return Value of the item id
 */
 native int Shop_GetItemValue(ItemId item_id);
 
 /**
  *	Sets an item count if item is finite and duration if item is togglable or non-togglable (-1 unlimited)
- *	-
+ *	
  *	@param item_id				Item id
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetItemValue(ItemId item_id, int value);
 
 /**
  *	Whether the item is exists (registered)
- *	-
+ *	
  *	@param item_id				Item id
- *	-
+ *	
  *	@return True if item is exists, false otherwise
 */
 native bool Shop_IsItemExists(ItemId item_id);
 
 /**
  *	Whether the category is valid (registered)
- *	-
+ *	
  *	@param category_id				Category id
- *	-
+ *	
  *	@return True if item is exists, false otherwise
 */
 native bool Shop_IsValidCategory(CategoryId category_id);
 
 /**
  *	Gets item id of the item unique name
- *	-
+ *	
  *	@param category_id				Category id where the item is registered
  *	@param item						Item unique name to get for
- *	-
+ *	
  *	@return Item id of the item
 */
 native ItemId Shop_GetItemId(CategoryId category_id, const char[] item);
 
 /**
  *	Gets the item unique name by its id
- *	-
+ *	
  *	@param item_id				Item id to get for
  *	@param buffer				Buffer to store the unique name
  *	@param maxlength			Max length of the buffer
- *	-
+ *	
  *	@return Number of bytes written
 */
 native int Shop_GetItemById(ItemId item_id, char[] buffer, int maxlength);
 
 /**
  *	Gets the item type
- *	-
+ *	
  *	@param item_id				Item id to get for
- *	-
+ *	
  *	@return Item type of the item. See ItemType enumeration
 */
 native ItemType Shop_GetItemType(ItemId item_id);
 
 /**
  *	Get unique name of item
- *	-
+ *	
  *	@param item_id				Item id to get for
  *	@param buffer				Buffer to store the unique name
  *	@param maxlength			Max length of the buffer
- *	-
+ *	
  *	@return Number of bytes written
 */
 native int Shop_GetItemNameById(ItemId item_id, char[] buffer, int maxlength);
 
 /**
  *	Get is feature "Try luck" enabled
- *	-
+ *	
  *	@param item_id				Item id to get for
- *	-
+ *	
  *	@return true - available, false - restricted
 */
 native bool Shop_GetItemCanLuck(ItemId item_id);
 
 /**
  *	Set feature "Try luck"
- *	-
+ *	
  *	@param item_id				Item id to set for
  *	@param bCanLuck			true - available, false - restricted
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetItemCanLuck(ItemId item_id, bool bCanLuck);
 
 /**
  *	Get is feature "Hide" enabled
- *	-
+ *	
  *	@param item_id				Item id to get for
- *	-
+ *	
  *	@return true - item hidden, false - available for buying
 */
 native bool Shop_GetItemHide(ItemId item_id);
 
 /**
  *	Set feature "Hide"
- *	-
+ *	
  *	@param item_id				Item id to set for
  *	@param state			true - to hide item, false - to show in buyable list
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetItemHide(ItemId item_id, bool state);
 
 /**
  *	Gets the item's category id
- *	-
+ *	
  *	@param item_id				Item id to get category id from
- *	-
+ *	
  *	@return Category id or INVALID_CATEGORY if category is not set or item id is invalid
 */
 native CategoryId Shop_GetItemCategoryId(ItemId item_id);
 
 /**
  *	Gets category id of the category unique name
- *	-
+ *	
  *	@param category				Category unique name to get id for
- *	-
+ *	
  *	@return Category id of the category
 */
 native CategoryId Shop_GetCategoryId(const char[] category);
 
 /**
  *	Gets the category unique name by its id
- *	-
+ *	
  *	@param category_id			Category id to get for
  *	@param buffer				Buffer to store the unique name
  *	@param maxlength			Max length of the buffer
- *	-
+ *	
  *	@return True on success, false otherwise
 */
 native bool Shop_GetCategoryById(CategoryId category_id, char[] buffer, int maxlength);
 
 /**
  *	Получает имя категории
- *	-
+ *	
  *	@param category_id			Category id to get for
  *	@param buffer				Buffer to store the unique name
  *	@param maxlength			Max length of the buffer
- *	-
+ *	
  *	@return True on success, false otherwise
 */
 native bool Shop_GetCategoryNameById(CategoryId category_id, char[] buffer, int maxlength);
 
 /**
  *	Fills an adt_array by the item ids. Note that array is cleared before being filled
- *	-
+ *	
  *	@param array			ADT array to use
- *	-
+ *	
  *	@return Number of bytes that written to ArrayList
 */
 native int Shop_FillArrayByItems(ArrayList array);
 
 /**
  *	Formats item display name to use in menu
- *	-
+ *	
  *	@param client			Client index to get format for
  *	@param item_id			Item id to format
  *	@param menu				Menu to get formatted for
  *	@param buffer			Buffer to store the result in
  *	@param maxlength		Max length of the buffer
- *	-
+ *	
  *	@return True if item formatted, false if param menu is Menu_Inventory and the player has not this item and the item is not formatted
 */
 native bool Shop_FormatItem(int client, ItemId item_id, ShopMenu menu, char[] buffer, int maxlength);
 
 /**
  *	Creates and ADT array of item ids
- *	-
+ *	
  *	@param size			Optional param to store array size
- *	-
+ *	
  *	@return ArrayList
 */
 stock ArrayList Shop_CreateArrayOfItems(int &size = 0)
@@ -491,16 +491,17 @@ stock ArrayList Shop_CreateArrayOfItems(int &size = 0)
 
 /**
  *	Retrieves an item id from an array
- *	-
+ *	
  *	@param array			Array handle
  *	@param index			Index in the array
- *	-
+ *	
  *	@return Item id
 */
 stock ItemId Shop_GetArrayItem(ArrayList array, int index)
 {
 	return view_as<ItemId>(array.Get(index));
 }
+
 //________________________________
 //|		CODE	HERE			  |
 //|		!Not necessary!			  |
@@ -509,11 +510,12 @@ stock ItemId Shop_GetArrayItem(ArrayList array, int index)
 // | || || || || |	| || || || || |	
 // \ /\ /\ /\ /\ /	\ /\ /\ /\ /\ /	
 //  V  V  V  V  V	 V  V  V  V  V	
+
 /**
  *	Gets array size
- *	-
+ *	
  *	@param array			Array handle
- *	-
+ *	
  *	@return Size of the array
 */
 #pragma deprecated Do not use it

--- a/addons/sourcemod/scripting/include/shop/players.inc
+++ b/addons/sourcemod/scripting/include/shop/players.inc
@@ -1,253 +1,253 @@
 /**
  *	Gets a player's id for the database
- *	-
+ *	
  *	@param client			Client index to get for
- *	-
+ *	
  *	@return player id in the database or 0 if client doesn't in database
 */
 native int Shop_GetClientId(int client);
 
 /**
  *	Sets timeleft for an item. 0 to set no timelimit
- *	-
+ *	
  *	@param client			Client index to set to
  *	@param item_id			Item id to set for
  *	@param timeleft			Timeleft to set. 0 to make it forever
  *	@param reset_duration	Reset duration
- *	-
+ *	
  *	@return True on success and false it client has not this item
 */
 native bool Shop_SetClientItemTimeleft(int client, ItemId item_id, int timeleft, bool reset_duration = true);
 
 /**
  *	Gets timeleft for an item
- *	-
+ *	
  *	@param client			Client index to get from
  *	@param item_id		Item id to get for
- *	-
+ *	
  *	@return item timeleft in seconds. 0 if item has no timelimit
 */
 native int Shop_GetClientItemTimeleft(int client, ItemId item_id);
 
 /**
  *	Gets an absolute sell price for an item a player hold
- *	-
+ *	
  *	@param client			Client index to get from
  *	@param item_id			Item id to get for
  *  @param isGold			True to retrieve gold value, false to get credits
- *	-
+ *	
  *	@return sell price of the item
 */
 native int Shop_GetClientItemSellPrice(int client, ItemId item_id, bool isGold = false);
 
 /**
  *	Whether a player has toggled on an item
- *	-
+ *	
  *	@param client			Client index to check to
  *	@param item_id		Item id to check
- *	-
+ *	
  *	@return true if player has item toggled on and false otherwise
 */
 native bool Shop_IsClientItemToggled(int client, ItemId item_id);
 
 /**
  *	Whether a player has an item
- *	-
+ *	
  *	@param client			Client index to check to
  *	@param item_id		Item id to check
- *	-
+ *	
  *	@return true if player has item and false otherwise
 */
 native bool Shop_IsClientHasItem(int client, ItemId item_id);
 
 /**
  *	Toggles a client's item
- *	-
+ *	
  *	@param client			Client index
  *	@param item_id		Item id to toggle
  *	@param toggle		Toggle state. See ToggleState enum
- *	-
+ *	
  *	@return true on success and false otherwise
 */
 native bool Shop_ToggleClientItem(int client, ItemId item_id, ToggleState toggle = Toggle);
 
 /**
  *	Toggles all items of category off
- *	-
+ *	
  *	@param client			Client index
  *	@param category_id		The category id
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_ToggleClientCategoryOff(int client, CategoryId category_id);
 
 /**
  *	Checks whether the player has been loaded from database
- *	-
+ *	
  *	@param client	Client index to check
- *	-
+ *	
 	@return	True if the player loaded, false otherwise
 */
 native bool Shop_IsAuthorized(int client);
 
 /**
  *	Checks whether a player has access to admin panel
- *	-
+ *	
  *	@param client	Client index to check
- *	-
+ *	
 	@return	True if the player has access, false otherwise
 */
 native bool Shop_IsAdmin(int client);
 
 /**
  *	Gives certain amount of credits to the player
- *	-
+ *	
  *	@param client			Client index
  *	@param amount			Amount to give
  *	@param by_who			Optional param to set by who the credits being given from
- *	-
+ *	
  *	@return	New amount of credits
 */
 native int Shop_GiveClientCredits(int client, int amount, int by_who = CREDITS_BY_NATIVE);
 
 /**
  *	Takes certain amount of credits from the player
- *	-
+ *	
  *	@param client			Client index
  *	@param amount			Amount to take
  *	@param by_who			Optional param to set by who the credits being given from
- *	-
+ *	
  *	@return	New amount of credits
 */
 native int Shop_TakeClientCredits(int client, int amount, int by_who = CREDITS_BY_NATIVE);
 
 /**
  *	Gets the amount of credits of the player
- *	-
+ *	
  *	@param client			Client index
- *	-
+ *	
  *	@return	Amount of credits a player has, -1 on failure
 */
 native int Shop_GetClientCredits(int client);
 
 /**
  *	Sets the amount of credits to the player
- *	-
+ *	
  *	@param client			Client index
  *	@param credits			Amount of credits to set
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetClientCredits(int client, int credits);
 
 /**
  *	Gives certain amount of gold to the player
- *	-
+ *	
  *	@param client			Client index
  *	@param amount			Amount to give
  *	@param by_who			Optional param to set by who the gold being given from
- *	-
+ *	
  *	@return	New amount of gold
 */
 native int Shop_GiveClientGold(int client, int amount, int by_who = CREDITS_BY_NATIVE);
 
 /**
  *	Takes certain amount of gold from the player
- *	-
+ *	
  *	@param client			Client index
  *	@param amount			Amount to take
  *	@param by_who			Optional param to set by who the gold being given from
- *	-
+ *	
  *	@return	New amount of gold
 */
 native int Shop_TakeClientGold(int client, int amount, int by_who = CREDITS_BY_NATIVE);
 
 /**
  *	Gets the amount of gold of the player
- *	-
+ *	
  *	@param client			Client index
- *	-
+ *	
  *	@return	Amount of gold a player has, -1 on failure
 */
 native int Shop_GetClientGold(int client);
 
 /**
  *	Sets the amount of gold to the player
- *	-
+ *	
  *	@param client			Client index
  *	@param amount			Amount of gold to set
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetClientGold(int client, int amount);
 
 /**
  *	Forces the player to buy the item from the shop
- *	-
+ *	
  *	@param client			Client index
  *	@param item_id			The item id
- *	-
+ *	
  *	@return	True if the player successfuly bought, false otherwise
 */
 native bool Shop_BuyClientItem(int client, ItemId item_id);
 
 /**
  *	Forces the player to sell the item from the inventory
- *	-
+ *	
  *	@param client			Client index
  *	@param item_id			The item id
- *	-
+ *	
  *	@return	True if the player successfuly sold, false otherwise
 */
 native bool Shop_SellClientItem(int client, ItemId item_id);
 
 /**
  *	Remove the item from the player's inventory
- *	-
+ *	
  *	@param client			Client index
  *	@param item_id			The item id
  *	@param count			Number of count to remove
- *	-
+ *	
  *	@return	True on success, false otherwise
 */
 native bool Shop_RemoveClientItem(int client, ItemId item_id, int count = 0);
 
 /**
  *	Gives the item from the player's inventory
- *	-
+ *	
  *	@param client			Client index
  *	@param item_id			The item id
  *	@param value			Count if the item is finite and duration if the item is togglable or non-togglable.
- *	-
+ *	
  *	@return	True on success, false otherwise
 */
 native bool Shop_GiveClientItem(int client, ItemId item_id, int value = 1);
 
 /**
  *	Get's count of an item a player has
- *	-
+ *	
  *	@param client			Client index
  *	@param item_id			The item id
- *	-
+ *	
  *	@return	Amount of item that player has
 */
 native int Shop_GetClientItemCount(int client, ItemId item_id);
 
 /**
  *	Set count of an item a player has
- *	-
+ *	
  *	@param client			Client index
  *	@param item_id			The item id
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetClientItemCount(int client, ItemId item_id, int count = 0);
 /**
  *	Forces a player to use an item
- *	-
+ *	
  *	@param client			Client index to force to
  *	@param item_id		Item id to force for
- *	-
+ *	
  *	@return true on success and false otherwise
 */
 native bool Shop_UseClientItem(int client, ItemId item_id);

--- a/addons/sourcemod/scripting/include/shop/register.inc
+++ b/addons/sourcemod/scripting/include/shop/register.inc
@@ -29,17 +29,17 @@ typeset Shop_ItemSellCallback
 /**
  *	Called when category registered at first time
  *  That means only once per unique name
- *	-
+ *	
  *	@param category_id		CategoryId of category
  *	@param name				Unique name of category
- *	-
+ *	
  *	@noreturn
 */
 forward void Shop_OnCategoryRegistered(CategoryId category_id, const char[] name);
 
 /**
  *	Registers new category id
- *	-
+ *	
  *	@param category				Category unique name
  *	@param name					Default category display name
  *	@param description			Default category description
@@ -47,7 +47,7 @@ forward void Shop_OnCategoryRegistered(CategoryId category_id, const char[] name
  *	@param cat_desc				Callback called on category's description being displayed
  *	@param cat_should			Callback called whether the category should be displayed to a player
  *	@param cat_select			Callback called when a player is trying to select the category
- *	-
+ *	
  *	@return Category id of the category
 */
 native CategoryId Shop_RegisterCategory(const char[] category, const char[] name, const char[] description, 
@@ -58,17 +58,17 @@ native CategoryId Shop_RegisterCategory(const char[] category, const char[] name
 
 /**
  *	Starts an item to register
- *	-
+ *	
  *	@param category_id			Category id to register an item for
  *	@param item					Item unique name
- *	-
+ *	
  *	@return true to success, false otherwise
 */
 native bool Shop_StartItem(CategoryId category_id, const char[] item);
 
 /**
  *	Sets the item information
- *	-
+ *	
  *	@param name					Default display name
  *	@param description			Default description
  *	@param price				Item price. Can not be lower than sell_price (on gold version can be lower and -1 for disable price by gold)
@@ -77,23 +77,23 @@ native bool Shop_StartItem(CategoryId category_id, const char[] item);
  *	@param value				Sets count if the item type is finite and sets duration if the item is togglable or non-togglable
  *	@param gold_price			Item price. Can be -1 to make in unbuyable by gold
  *	@param gold_sell_price		Item sell price. 0 to make item free by gold price and -1 to disable sell by gold. Can not be higher than price
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetInfo(const char[] name, const char[] description, int price, int sell_price = -1, ItemType type, int value = 1, int gold_price = -1, int gold_sell_price = -1);
 
 /**
  *	Sets the item luck chance.
- *	-
+ *	
  *	@param luck_chance			Luck chance to set. From 0 to 100. 0 can not be lucked and 100 is always lucked by the general chance set in cvar. Default item chance is 100
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetLuckChance(int luck_chance);
 
 /**
  *	Sets the item callbacks
- *	-
+ *	
  *	@param register				Callback called when the item is registered
  *	@param use_toggle			Callback called when the item is being used
  *	@param should				Callback called when the item is being displayed. Here you can stop displaying the item
@@ -103,7 +103,7 @@ native void Shop_SetLuckChance(int luck_chance);
  *	@param buy					Callback called when the item is being bought
  *	@param sell					Callback called when the item is being sold
  *	@param elapse				Callback called when the item is elapsed
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetCallbacks(Shop_ItemRegister register=INVALID_FUNCTION,
@@ -118,58 +118,58 @@ native void Shop_SetCallbacks(Shop_ItemRegister register=INVALID_FUNCTION,
 
 /**
  *	Allows to hide item in buy panel, givable only by native or admin panel
- *	-
+ *	
  *	@param state			true - hide, false - show
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetHide(bool state);
 
 /**
  *	Sets item custom info
- *	-
+ *	
  *	@param info			Name of the key
  *	@param value			Value to set
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetCustomInfo(const char[] info, int value);
 
 /**
  *	Sets item custom info
- *	-
+ *	
  *	@param info			Name of the key
  *	@param value			Value to set
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetCustomInfoFloat(const char[] info, float value);
 
 /**
  *	Sets item custom info
- *	-
+ *	
  *	@param info			Name of the key
  *	@param value			Value to set
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_SetCustomInfoString(const char[] info, char[] value);
 
 /**
  *	Copies sub keys of the given kv structure to the item
- *	-
+ *	
  *	@param info			Name of the key
  *	@param value			Value to set
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_KvCopySubKeysCustomInfo(KeyValues kv);
 
 /**
  *	Copletes the item info structure and start to register. Can not be used before an item has been started to register
- *	-
+ *	
  *	@noparams
- *	-
+ *	
  *	@noreturn
 */
 native void Shop_EndItem();


### PR DESCRIPTION
Докген не очень любит "левые символы" при парсинге комментариев, что приводит к их появлению в текстах:
![image](https://user-images.githubusercontent.com/12576822/85200224-9ccbd080-b306-11ea-985a-07219aab16b7.png)
