### PR TITLE
Fixed two year old memory leak in PlayerManager_GetClientItems.

### DIFF
--- a/addons/sourcemod/scripting/shop/player_manager.sp
+++ b/addons/sourcemod/scripting/shop/player_manager.sp
@@ -636,7 +636,7 @@ public int PlayerManager_ToggleClientCategoryOff(Handle plugin, int numParams)
 	h_KvClientItems[client].Rewind();
 }
 
-public int PlayerManager_GetClientItems(Handle plugin, int numParams)
+public any PlayerManager_GetClientItems(Handle plugin, int numParams)
 {
 	int client = GetNativeCell(1);
 	
@@ -659,7 +659,9 @@ public int PlayerManager_GetClientItems(Handle plugin, int numParams)
 		while (hKVItems.GotoNextKey());
 	}
 
-	return view_as<int>(hArrayItems);
+	ArrayList _hArrayItems = view_as<ArrayList>(CloneHandle(hArrayItems, plugin));
+	delete hArrayItems;
+	return _hArrayItems;
 }
 
 public Action PlayerManager_OnPlayerItemElapsed(Handle timer, DataPack dp)


### PR DESCRIPTION
This native was created 2 years ago b8fdd49

While writing my plugin, I noticed that if you create a Handle in a plugin and then return it directly in the native to another plugin (module), then this Handle binds to the plugin where it was created. And if you do not delete this Handle in the module after that, and even when you reboot the module, the Handle will remain valid, which will create a leak. I decided to check it out in the shop, and suddenly I found it.  😄 
I found a way out, after creating Handle we copy it with another plugin via [CloneHandle()](https://sourcemod.dev/#/handles/function.CloneHandle) (second argument).

Test code:
```cpp
#include <shop>

public void OnPluginStart()
{
    for(int i = 1; i <= MaxClients; i++)	if(IsClientAuthorized(i) && IsClientInGame(i) && !IsFakeClient(i)) {
        for(int c; c < 50; c++) {
            LogToFile("1 Shop test leak log.txt", "%x", Shop_GetClientItems(client));
        }
    }
}
```

I reloaded the test plugin with the sm plugins reload command several dozen times. And then get a lot of unclosed arrays, which indicates a leak.

Here are the files with the test results, according to the log you can see which Handles I received and which remained in the dump (spoiler: all 1650 received Handles remained).
[1 Handles BEFORE test.txt](https://github.com/FD-Forks/Shop-Core/files/8384810/1.Handles.BEFORE.test.txt)
[1 Shop test leak log.txt](https://github.com/FD-Forks/Shop-Core/files/8384811/1.Shop.test.leak.log.txt)
[1 Handles AFTER tes.txt](https://github.com/FD-Forks/Shop-Core/files/8384812/1.Handles.AFTER.tes.txt)