### PR TITLE
Fixed lack of bytes for the output of Russian characters

### DIFF
--- a/addons/sourcemod/scripting/shop.sp
+++ b/addons/sourcemod/scripting/shop.sp
@@ -1316,7 +1316,7 @@ void ConfirmSell(int client, int item_id)
 	if (panel == null)
 		return;
 
-	char sBuffer[SHOP_MAX_STRING_LENGTH], sItemId[16];
+	char sBuffer[256], sItemId[16];
 	IntToString(item_id, sItemId, sizeof(sItemId));
 	
 	SetGlobalTransTarget(client);

--- a/addons/sourcemod/scripting/shop.sp
+++ b/addons/sourcemod/scripting/shop.sp
@@ -1249,7 +1249,7 @@ void ConfirmBuy(int client, int item_id)
 	if (panel == null)
 		return;
 
-	char sBuffer[SHOP_MAX_STRING_LENGTH], sItemId[16];
+	char sBuffer[256], sItemId[16];
 	IntToString(item_id, sItemId, sizeof(sItemId));
 	
 	SetGlobalTransTarget(client);


### PR DESCRIPTION
The value of SHOP_MAX_STRING_LENGTH is 64, it is not enough in the Title to correctly display the text in Russian, it turns out to be cropped.

Before:
![изображение](https://user-images.githubusercontent.com/52104782/164302119-1af71f9b-8985-4edc-89f8-29c52bfa2f77.png)

After:
![изображение](https://user-images.githubusercontent.com/52104782/164302181-34533838-d77e-4f35-b054-2c9c929f2602.png)
